### PR TITLE
NP-312: Allowed locale gb September formatting in our tests, as it does not break EIS/PDS

### DIFF
--- a/test-common/uk/gov/hmrc/uknwauthcheckerapi/generators/TestRegexes.scala
+++ b/test-common/uk/gov/hmrc/uknwauthcheckerapi/generators/TestRegexes.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.uknwauthcheckerapi.generators
 
 object TestRegexes {
-  val rfc7231DateTimePattern: String = "^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), ([0-3][0-9]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)" +
+  val rfc7231DateTimePattern: String = "^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), ([0-3][0-9]) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)" +
     " ([0-9]{4}) ([01][0-9]|2[0-3])(:[0-5][0-9]){2} [A-Z][A-Z][A-Z]$"
   val uuidPattern: String = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 }


### PR DESCRIPTION
- Related info: https://stackoverflow.com/a/69268271
- Need to allow the original Sep as the app might be run non en-gb locale