### PR TITLE
NP-Routes: Moved definition.routes into it's own package to fix PR builder reported issue

### DIFF
--- a/app/uk/gov/hmrc/uknwauthcheckerapi/controllers/docs/DocumentationController.scala
+++ b/app/uk/gov/hmrc/uknwauthcheckerapi/controllers/docs/DocumentationController.scala
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.uknwauthcheckerapi.controllers
-
-import javax.inject.{Inject, Singleton}
+package uk.gov.hmrc.uknwauthcheckerapi.controllers.docs
 
 import controllers.Assets
-
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+
+import javax.inject.{Inject, Singleton}
 
 @Singleton
 class DocumentationController @Inject() (assets: Assets, cc: ControllerComponents) extends BackendController(cc) {

--- a/app/uk/gov/hmrc/uknwauthcheckerapi/controllers/docs/DocumentationController.scala
+++ b/app/uk/gov/hmrc/uknwauthcheckerapi/controllers/docs/DocumentationController.scala
@@ -16,11 +16,12 @@
 
 package uk.gov.hmrc.uknwauthcheckerapi.controllers.docs
 
+import javax.inject.{Inject, Singleton}
+
 import controllers.Assets
+
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
-
-import javax.inject.{Inject, Singleton}
 
 @Singleton
 class DocumentationController @Inject() (assets: Assets, cc: ControllerComponents) extends BackendController(cc) {

--- a/conf/definition.routes
+++ b/conf/definition.routes
@@ -1,2 +1,2 @@
-GET        /api/definition                 uk.gov.hmrc.uknwauthcheckerapi.controllers.DocumentationController.definition()
-GET        /api/conf/:version/*file        uk.gov.hmrc.uknwauthcheckerapi.controllers.DocumentationController.specification(version, file)
+GET        /api/definition                 uk.gov.hmrc.uknwauthcheckerapi.controllers.docs.DocumentationController.definition()
+GET        /api/conf/:version/*file        uk.gov.hmrc.uknwauthcheckerapi.controllers.docs.DocumentationController.specification(version, file)


### PR DESCRIPTION
The following was the pr builder error which this PR fixes:

> You have multiple routes files conf/app.routes, conf/definition.routes using the same package uk.gov.hmrc.uknwauthcheckerapi.controllers, which leads to collision with the reverse routes. Please ensure each routes file refers to a different package.